### PR TITLE
Remove unnecessary rspec dependency

### DIFF
--- a/lib/mundipagg_sdk.rb
+++ b/lib/mundipagg_sdk.rb
@@ -4,7 +4,6 @@ require 'bundler/setup'
 require 'json'
 require 'rest-client'
 require 'nori'
-require 'rspec'
 require 'rexml/document'
 
 require_relative 'gateway/BoletoTransaction/boleto_transaction'

--- a/mundipagg_sdk.gemspec
+++ b/mundipagg_sdk.gemspec
@@ -6,14 +6,15 @@ Gem::Specification.new do |s|
   s.author = 'MundiPagg'
   s.email = 'github@mundipagg.com'
   s.homepage = 'http://www.mundipagg.com/'
-  s.files = Dir.glob ["README.md", "LICENSE", "lib/**/*.{rb}", "spec/**/*", "*.gemspec"]
+  s.files = Dir.glob ["README.md", "LICENSE", "lib/**/*.{rb}", "*.gemspec"]
+  s.test_files = Dir.glob ["spec/**/*"]
   s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
-  s.add_dependency 'rspec', '~> 3.3', '>= 3.3.0'
   s.add_dependency 'nori', '~> 2.6', '>= 2.6.0'
   s.add_dependency 'gyoku', '~> 1.3', '>= 1.3.1'
   s.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.6.2'
   s.add_dependency 'ffi', '~> 1.9', '>= 1.9.10'
   s.add_dependency 'bundler', '~> 1.10', '>= 1.10.6'
+  s.add_development_dependency 'rspec', '~> 3.3', '>= 3.3.0'
   s.required_ruby_version = '>= 2.1.7'
   s.license = 'Apache 2.0'
 end


### PR DESCRIPTION
This dependency is needed only for development purposes, applications that don't use rspec should not have the additional load.

Also remove the test files from the gem.