### PR TITLE
Feature/urls - :art: Adds support to inject service urls from constructor

### DIFF
--- a/mundipagg_sdk.gemspec
+++ b/mundipagg_sdk.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name = 'mundipagg_sdk'
   s.summary = 'MundiPagg Ruby Client Library'
   s.description = 'Ruby library for integrating with the MundiPagg payment web services'
-  s.version = '1.3.0' # Major.Minor.Revision
+  s.version = '1.4.0' # Major.Minor.Revision
   s.author = 'MundiPagg'
   s.email = 'github@mundipagg.com'
   s.homepage = 'http://www.mundipagg.com/'

--- a/spec/integration/gateway_spec.rb
+++ b/spec/integration/gateway_spec.rb
@@ -3,7 +3,7 @@ require_relative 'test_helper'
 
 merchant_key = '85328786-8BA6-420F-9948-5352F5A183EB'
 
-gateway = Gateway::Gateway.new(:sandbox, merchant_key)
+gateway = Gateway::Gateway.new('https://sandbox.mundipaggone.com', 'https://apisandbox.mundipaggone.com', merchant_key)
 
 RSpec.describe Gateway do
   it 'should create a sale with boleto' do

--- a/spec/integration/gateway_spec.rb
+++ b/spec/integration/gateway_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe Gateway do
 
     expect(split_commas[1]).to eq '20150919'
   end
-
+  
   it 'should parse the transaction report file received' do
     date = Date.new(2015, 9, 19)
     request_to_parse = gateway.TransactionReportFile(date)

--- a/spec/integration/gateway_spec.rb
+++ b/spec/integration/gateway_spec.rb
@@ -3,7 +3,7 @@ require_relative 'test_helper'
 
 merchant_key = '85328786-8BA6-420F-9948-5352F5A183EB'
 
-gateway = Gateway::Gateway.new('https://sandbox.mundipaggone.com', 'https://apisandbox.mundipaggone.com', merchant_key)
+gateway = Gateway::Gateway.new(:sandbox, merchant_key)
 
 RSpec.describe Gateway do
   it 'should create a sale with boleto' do

--- a/spec/integration/gateway_spec.rb
+++ b/spec/integration/gateway_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../lib/mundipagg_sdk'
 require_relative 'test_helper'
+require 'date'
 
 merchant_key = '85328786-8BA6-420F-9948-5352F5A183EB'
 
@@ -620,7 +621,7 @@ RSpec.describe Gateway do
 
     expect(split_commas[1]).to eq '20150919'
   end
-  
+
   it 'should parse the transaction report file received' do
     date = Date.new(2015, 9, 19)
     request_to_parse = gateway.TransactionReportFile(date)
@@ -699,7 +700,7 @@ RSpec.describe Gateway do
     credit_card_transaction.CreditCard.ExpMonth = 10
     credit_card_transaction.CreditCard.ExpYear = 2018
     credit_card_transaction.CreditCard.SecurityCode = '123'
-    credit_card_transaction.CreditCard.HolderName = 'Luke Skywalker'
+    credit_card_transaction.CreditCard.HolderName = 'Luke Skywalker' + DateTime.now().to_s
     credit_card_transaction.AmountInCents = 100
 
     sale_request = Gateway::CreateSaleRequest.new


### PR DESCRIPTION
From now on you can send trough the constructor URLs for One API and TransactionReportFile if you want. If you don't want it just leave the way it always was.